### PR TITLE
開発環境の更新: Unreal Engine 5.6 & Windows 11 SDK

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,10 +1,14 @@
 {
   "version": "1.0",
   "components": [
+    "Component.Unreal.Debugger",
+    "Component.Unreal.Ide",
     "Microsoft.Net.Component.4.6.2.TargetingPack",
+    "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL",
     "Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    "Microsoft.VisualStudio.Component.Windows10SDK.22621",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
     "Microsoft.VisualStudio.Workload.CoreEditor",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.NativeDesktop",

--- a/TP_VRProject.uproject
+++ b/TP_VRProject.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.4",
+	"EngineAssociation": "5.6",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
`.vsconfig` ファイルに新しいコンポーネントを追加し、Windows 10 SDK を削除しました。これにより、Unreal Engine 開発環境が強化され、最新の Windows 11 SDK に対応しました。

`TP_VRProject.uproject` ファイルでは、Unreal Engine のバージョンを 5.4 から 5.6 に更新しました。これにより、最新のエンジン機能を活用可能になりました。